### PR TITLE
add description meta tag to rendered pages

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,6 +2,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>{{ block "title" . }}{{ if .Title }}{{ .Title }} | {{ end }}{{end }}{{ .Site.Title }}</title>
+  <meta name="description" content="{{if .IsHome}}{{ $.Site.Params.description }}{{else}}{{.Description}}{{end}}" />
   <link rel="icon" type="image/png" href="/assets/favicon.png" sizes="16x16">  
   <link rel="icon" type="image/png" href="/assets/favicon.png" sizes="32x32">  
   <link rel="icon" type="image/png" href="/assets/favicon.png" sizes="96x96"> 


### PR DESCRIPTION
From the comment:
https://github.com/MrMinos/basicwebtheme/commit/84b36964b45648ae5c3059b2a465007fdcaf569c#comments

If the rendered page is the home page as signaled by `.IsHome` flag, then use the config file's `Params.description`; otherwise, use the `description` front matter from the rendered page.